### PR TITLE
Fix notification start up script. We were hitting the default

### DIFF
--- a/templates/monasca-notification.service.j2
+++ b/templates/monasca-notification.service.j2
@@ -7,6 +7,7 @@ Type=simple
 User={{ notification_user }}
 Group={{ monasca_group }}
 Restart=always
+RestartSec=10
 ExecStart={{ monasca_virtualenv_dir }}/bin/monasca-notification
 
 [Install]


### PR DESCRIPTION
retry limit on failure so the notification engine would just die