### PR TITLE
Fix mode arguments to be octal not decimal numbers

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -8,13 +8,13 @@
   user: name={{notification_user}} system=yes group={{monasca_group}}
 
 - name: create notification log dir
-  file: path={{notification_log_dir}} state=directory owner=root group={{monasca_group}} mode=775
+  file: path={{notification_log_dir}} state=directory owner=root group={{monasca_group}} mode=0775
 
 - name: create conf dir
-  file: path={{monasca_conf_dir}} state=directory owner=root group={{monasca_group}} mode=775
+  file: path={{monasca_conf_dir}} state=directory owner=root group={{monasca_group}} mode=0775
 
 - name: create conf file from template
-  template: dest="{{monasca_conf_dir}}/notification.yaml" owner={{notification_user}} group={{monasca_group}} mode=640 src=notification.yaml.j2
+  template: dest="{{monasca_conf_dir}}/notification.yaml" owner={{notification_user}} group={{monasca_group}} mode=0640 src=notification.yaml.j2
   notify:
     - restart monasca-notification
 
@@ -27,13 +27,13 @@
   when: init.stdout != 'systemd'
 
 - name: create upstart script
-  template: dest={{notification_upstart_conf}} owner=root group=root mode=644 src=monasca-notification.conf.j2
+  template: dest={{notification_upstart_conf}} owner=root group=root mode=0644 src=monasca-notification.conf.j2
   notify:
     - restart monasca-notification
   when: not use_systemd
 
 - name: create systemd config
-  template: dest={{notification_systemd_service}} owner=root group=root mode=644 src=monasca-notification.service.j2
+  template: dest={{notification_systemd_service}} owner=root group=root mode=0644 src=monasca-notification.service.j2
   notify:
     - restart monasca-notification
   when: use_systemd

--- a/tasks/pip_index.yml
+++ b/tasks/pip_index.yml
@@ -2,9 +2,9 @@
 # ©Copyright 2015 Hewlett-Packard Development Company, L.P.
 
 - name: Create pip conf dir if pip index URL specified
-  file: path={{ pip_conf_dir }} state=directory owner=root group=root mode=770
+  file: path={{ pip_conf_dir }} state=directory owner=root group=root mode=0770
   when: pip_index_url is defined
 
 - name: Use pip index URL if specified
-  template: dest="{{ pip_conf_dir }}/pip.conf" src=pip.conf.j2 backup=yes owner=root group=root mode=660
+  template: dest="{{ pip_conf_dir }}/pip.conf" src=pip.conf.j2 backup=yes owner=root group=root mode=0660
   when: pip_index_url is defined


### PR DESCRIPTION
From the ansible documentation:
"For those used to /usr/bin/chmod remember that modes are
actually octal numbers (like 0644). Leaving off the leading
zero will likely have unexpected results."